### PR TITLE
회원가입fetch 가능하게 수정

### DIFF
--- a/client/src/feature/signup/signup.tsx
+++ b/client/src/feature/signup/signup.tsx
@@ -21,8 +21,8 @@ function Signup() {
     password: "",
     nickname: "",
     user_address: "",
-    latitude: 0,
-    longitude: 0,
+    latitude: "",
+    longitude: "",
   });
   /*실제 api.ts에서 서버로 보내는 트리거'signup'과 {data,isLoading,isSuccess} */
   const [signup, { data, isLoading, isSuccess }] = useSignupMutation();
@@ -31,8 +31,8 @@ function Signup() {
   //kakao 주소 api
   //주소 상태를 선언
   const [fullAddress, setFullAddress] = useState("");
-  const [latitude, setLatitude] = useState(0);
-  const [longitude, setLongitude] = useState(0);
+  const [latitude, setLatitude] = useState("");
+  const [longitude, setLongitude] = useState("");
 
   useEffect(() => {
     // 주소-좌표 변환 객체를 생성합니다
@@ -89,7 +89,7 @@ function Signup() {
     console.log(inputValue);
     try {
       const user = await signup(inputValue).unwrap();
-      //   dispatch(setCredentials(user));
+      // dispatch(setCredentials(user));
       dispatch(setIsModal());
       console.log(user);
     } catch (err) {
@@ -139,7 +139,7 @@ function Signup() {
     setInputValue({ ...inputValue, user_address: value });
   };
   // 위도 경도 input function : 타자가 아닌 useEffect에 의해 kakaoAPI 받아오기 때문에 따로 만듬
-  const handleLatLongInputValue = (value1: number, value2: number) => {
+  const handleLatLongInputValue = (value1: string, value2: string) => {
     setInputValue({ ...inputValue, latitude: value1, longitude: value2 });
   };
 

--- a/client/src/services/api.ts
+++ b/client/src/services/api.ts
@@ -32,10 +32,9 @@ export interface LoginRequest {
 export interface MypageResponse {
   messgae: string;
   data: {
-    user_posts: [object]
-    userInfo: User
-  }
-
+    user_posts: [object];
+    userInfo: User;
+  };
 }
 // 회원가입 타입
 export interface SignupRequest {
@@ -43,15 +42,14 @@ export interface SignupRequest {
   password: string;
   nickname: string;
   user_address: string;
-  latitude: number;
-  longitude: number;
+  latitude: string;
+  longitude: string;
 }
 export interface SignupResponse {
   message: string;
 }
 export const api = createApi({
   baseQuery: fetchBaseQuery({
-
     baseUrl: "http://localhost:4000/",
     credentials: "include",
     prepareHeaders: (headers, { getState }) => {
@@ -67,44 +65,44 @@ export const api = createApi({
   endpoints: (builder) => ({
     login: builder.mutation<UserResponse, LoginRequest>({
       query: (credentials: any) => ({
-        url: 'users/login',
-        credentials: 'include', // true
-        method: 'POST',
+        url: "users/login",
+        credentials: "include", // true
+        method: "POST",
 
         body: credentials,
       }),
     }),
     logout: builder.mutation<{ message?: any }, void>({
       query: () => ({
-        url: 'users/logout',
-        credentials: 'include', // true
-        method: 'POST',
-      })
+        url: "users/logout",
+        credentials: "include", // true
+        method: "POST",
+      }),
     }),
     // data: { user_posts: posts, userinfo: user }
     mypage: builder.mutation<any, void>({
       query: () => ({
-        url: 'users/mypage',
-        credentials: 'include', // true
-        method: 'GET',
-      })
+        url: "users/mypage",
+        credentials: "include", // true
+        method: "GET",
+      }),
     }),
     posts: builder.mutation<any, void>({
       query: (formdata) => ({
-        url: 'tools',
-        credentials: 'include', // true
-        method: 'POST',
+        url: "tools",
+        credentials: "include", // true
+        method: "POST",
         // headers: {
         //   'content-type': 'multipart/form-data',
         // },
         body: formdata,
         // responseHandler: (response) => response.text(),
-      })
+      }),
     }),
     signup: builder.mutation<SignupResponse, SignupRequest>({
       query: (setSignupData: any) => ({
-        url: "signup",
-        setSignupData: "include",
+        url: "users/signup",
+        credentials: "include",
         method: "POST",
         body: setSignupData,
       }),
@@ -118,5 +116,4 @@ export const {
   useLogoutMutation,
   useMypageMutation,
   usePostsMutation,
-} = api
-
+} = api;


### PR DESCRIPTION
1. 회원가입이 갑자기 안됨.

온갖 방법을 사용

해결 된 방법 :
이전에 받아온 file에서는 services/api에 baseQuery가 localhost:4000/user이였다면 이번에 localhost:4000/으로 바뀌었기 때문에

회원가입 이전 url: "signup"을 url: "users/signup"으로 바꾸어 줘야 했다. 

이후 회원가입이 다시 잘 됨.

기타 수정사항 - 위도 경도의 데이터 type을 number에서 다시 string으로 변경